### PR TITLE
feat: trigger README generation immediately on first repo activation

### DIFF
--- a/server/src/controllers/github.controller.js
+++ b/server/src/controllers/github.controller.js
@@ -136,6 +136,42 @@ export const addRepoActivity = async (req, res) => {
 
     await activeRepo.save();
 
+    // On first-ever activation, immediately trigger README generation
+    // so users don't have to make a commit themselves to see it work.
+    const hasBeenActivatedBefore = await ActiveRepo.findOne({
+      userId,
+      repoId,
+      active: false,
+    });
+    if (!hasBeenActivatedBefore) {
+      try {
+        const refRes = await githubGet(
+          `${GITHUB_API_BASE}/repos/${repoOwner}/${repoName}/git/ref/heads/${defaultBranch}`,
+          accessToken,
+        );
+        const headSha = refRes.data.object.sha;
+
+        await readmeQueue.add("generate-readme", {
+          userId,
+          repoId,
+          repoName,
+          repoFullName,
+          repoOwner,
+          defaultBranch,
+          commitSha: headSha,
+        });
+
+        activeRepo.lastProcessedSha = headSha;
+        await activeRepo.save();
+      } catch (err) {
+        console.error(
+          "Failed to trigger initial README generation:",
+          err.message,
+        );
+        // Non-fatal: repo is still activated, pipeline just won't auto-start
+      }
+    }
+
     res.status(200).json({ message: "Repository activity added successfully" });
   } catch (error) {
     res


### PR DESCRIPTION
## Problem
  When a user enables the toggle for a repo for the first time, nothing happens until they manually push a commit. This
  caused users to think the product wasn't working.

## Solution
On first-ever activation, `addRepoActivity` now fetches the repo's current HEAD SHA via the GitHub ref API and enqueues a
`generate-readme` job directly — the same job the webhook handler would queue on a real push.

## Behaviour
- **First activation:** README generation fires immediately, no user action needed.
- **Re-activation (toggle off → on):** Skipped — detected by checking for an existing `active: false` record for that
repo. User is expected to push normally at this point.
- **Failure:** Non-fatal. If the ref fetch fails, the repo is still activated and falls back to the existing
webhook-on-push behaviour.

## What was NOT done
No dummy commit is created in the user's repo — avoids polluting commit history and eliminates the webhook round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic README generation: When a repository is activated for the first time, an automated process now queues a README generation task, streamlining the initial repository setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->