### PR TITLE
fix: verify GitHub webhooks using raw request body

### DIFF
--- a/server/src/controllers/github.controller.js
+++ b/server/src/controllers/github.controller.js
@@ -14,17 +14,23 @@ import { redis } from "../utils/redis.js";
 import { liveUpdate } from "../services/convex.service.js";
 
 export function verifyGithubSignature(req) {
+  if (!Buffer.isBuffer(req.body)) return false;
   const signature = req.headers["x-hub-signature-256"];
+
   if (!signature) return false;
 
   const hmac = crypto.createHmac("sha256", process.env.GITHUB_WEBHOOK_SECRET);
 
-  const payload =
-    typeof req.body === "string" ? req.body : JSON.stringify(req.body);
+  const digest = "sha256=" + hmac.update(req.body).digest("hex");
 
-  const digest = "sha256=" + hmac.update(payload).digest("hex");
+  const signatureBuffer = Buffer.from(signature, "utf8");
+  const digestBuffer = Buffer.from(digest, "utf8");
 
-  return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(digest));
+  if (signatureBuffer.length !== digestBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(signatureBuffer, digestBuffer);
 }
 
 export const getGithubRepos = async (req, res) => {
@@ -269,9 +275,7 @@ export const githubWebhookHandler = async (req, res) => {
       return res.status(200).send("Event ignored");
     }
 
-    const payload =
-      typeof req.body === "string" ? JSON.parse(req.body) : req.body;
-
+    const payload = JSON.parse(req.body.toString("utf8"));
     const repoId = payload.repository.id;
     const commitSha = payload.after;
     const commitMessage = payload.head_commit?.message || "";

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -6,6 +6,7 @@ import githubRoutes from "./routes/github.routes.js";
 import emailRoutes from "./routes/email.routes.js";
 import { connectDB } from "./db/connectDB.js";
 import { recoverInterruptedCleanupLogs } from "./services/logRecovery.service.js";
+import { githubWebhookHandler } from "./controllers/github.controller.js";
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -20,6 +21,12 @@ app.use(
     ],
     credentials: true,
   }),
+);
+
+app.use(
+  "/api/github/webhookhandler",
+  express.raw({ type: "application/json" }),
+  githubWebhookHandler,
 );
 
 app.use(express.json());

--- a/server/src/routes/github.routes.js
+++ b/server/src/routes/github.routes.js
@@ -3,20 +3,17 @@ import { authenticate, requireAdmin } from "../middlewares/auth.middleware.js";
 import {
   addRepoActivity,
   getGithubRepos,
-  githubWebhookHandler,
   deactivateRepoActivity,
   fetchUserLogs,
   fetchAdminAnalytics,
   fetchAdminUsers,
   cleanUpReadme,
 } from "../controllers/github.controller.js";
-
 const router = Router();
 
 router.get("/getGithubRepos", authenticate, getGithubRepos);
 router.post("/addRepoActivity", authenticate, addRepoActivity);
 router.post("/deactivateRepoActivity", authenticate, deactivateRepoActivity);
-router.post("/webhookhandler", githubWebhookHandler);
 router.get("/fetchUserLogs", authenticate, fetchUserLogs);
 router.get("/admin/analytics", authenticate, requireAdmin, fetchAdminAnalytics);
 router.get("/admin/users", authenticate, requireAdmin, fetchAdminUsers);


### PR DESCRIPTION
This pull request refactors how the GitHub webhook handler is registered and how webhook payloads are processed and verified. The main improvements are stricter payload handling for security, moving the webhook handler route to a dedicated endpoint, and ensuring signature verification is robust.

**Webhook payload handling and security:**

* The `verifyGithubSignature` function now strictly requires `req.body` to be a `Buffer` and compares the signature and digest using timing-safe equality, reducing the risk of signature spoofing.
* The webhook payload is now parsed from a `Buffer` using `toString("utf8")`, ensuring consistent and secure handling of incoming data.

**Route registration and organization:**

* The webhook handler (`githubWebhookHandler`) is now registered directly in `index.js` at the endpoint `/api/github/webhookhandler` with `express.raw({ type: "application/json" })`, ensuring the payload is passed as a raw buffer for signature verification. [[1]](diffhunk://#diff-ca1c659f55ca813ddb05ea5965e2e6c9a4a1d82a22f7067a2b34718cd4e83c4cR9) [[2]](diffhunk://#diff-ca1c659f55ca813ddb05ea5965e2e6c9a4a1d82a22f7067a2b34718cd4e83c4cR26-R31)
* The webhook handler route is removed from `github.routes.js`, centralizing its registration and avoiding conflicts with JSON body parsing middleware.

These changes improve the security and reliability of GitHub webhook processing in the application.